### PR TITLE
UTF-8 is not Unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Convenience methods are also provided for some major languages:
     ad.is_cjk(u'汉字') #True
 
 
-**NOTE: all strings are expected to be unicode (utf-8) to keep things consistent. Conversion is *never* done for you, and errors are thrown when a string is not unicode.**
+**NOTE: all strings are expected to be unicode to keep things consistent. Conversion is *never* done for you, and errors are thrown when a string is not unicode.**


### PR DESCRIPTION
UTF-8 is an encoding from Unicode characters to bytes; a UTF-8 string
is made out of bytes and will not itself be accepted by the library.
If you have a UTF-8 string, you must first decode it from UTF-8 into
Unicode before passing it to the library.

Discussed in the comments at
https://github.com/EliFinkelshteyn/alphabet-detector/commit/67120416591879293c7a23a3d3430b4b41f755e4

Signed-off-by: Anders Kaseorg andersk@mit.edu
